### PR TITLE
Fix quoting in update.sh

### DIFF
--- a/Web/gallery/update.sh
+++ b/Web/gallery/update.sh
@@ -72,7 +72,7 @@ done
 
 # Build the image list for the HTML file
 echo "Building image list for HTML file..." | tee -a "$LOG_FILE"
-updated_images=$(echo "$current_images" | awk '{for(i=1;i<=NF;i++) printf "\""$i"\","}')
+updated_images=$(echo "$current_images" | awk '{for(i=1;i<=NF;i++) printf "\"%s\",", $i}')
 updated_images=${updated_images%,} # Remove trailing comma
 echo "Updated image list for HTML: $updated_images" | tee -a "$LOG_FILE"
 


### PR DESCRIPTION
## Summary
- fix quoting in `update.sh` when building the image list so awk runs correctly

## Testing
- `bash -n Web/gallery/update.sh`

------
https://chatgpt.com/codex/tasks/task_e_683f39e4a3d0832583ece8bbd8a2d1b8