### PR TITLE
Fix gallery update when RSS file missing

### DIFF
--- a/Web/gallery/update.sh
+++ b/Web/gallery/update.sh
@@ -38,8 +38,8 @@ for image in "$SOURCE_DIR"/*.{jpg,png}; do
     current_images="$current_images $filename"
     echo "Detected image file: $image" | tee -a "$LOG_FILE"
 
-    # Check if the image is new by checking if it exists in the RSS feed
-    if ! grep -q "$filename" "$RSS_FILE"; then
+    # Check if the image is new. Skip the grep when the RSS file is missing
+    if [ ! -f "$RSS_FILE" ] || ! grep -q "$filename" "$RSS_FILE"; then
       new_images="$new_images $filename"
       echo "New image detected: $filename" | tee -a "$LOG_FILE"
     fi


### PR DESCRIPTION
## Summary
- avoid running grep if the RSS feed doesn't exist in `Web/gallery/update.sh`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683faa7d6d1c83258b37579d4e139204